### PR TITLE
fix SyntaxError: Non-ASCII

### DIFF
--- a/Grafana/elasticsearch2elastic.py
+++ b/Grafana/elasticsearch2elastic.py
@@ -123,4 +123,4 @@ if __name__ == '__main__':
         try:
             sys.exit(0)
         except SystemExit:
-            os._exit(0) 
+            os._exit(0)


### PR DESCRIPTION
SyntaxError: Non-ASCII character '\xc2' in file elasticsearch2elastic.py on line 126, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details