### PR TITLE
Compatible with  python 2.6

### DIFF
--- a/Grafana/elasticsearch2elastic.py
+++ b/Grafana/elasticsearch2elastic.py
@@ -37,13 +37,13 @@ def handle_urlopen(urlData, read_username, read_password):
         response = urllib2.urlopen(urlData)
 	return response
       except Exception as e:
-        print "Error:  {}".format(str(e))
+        print "Error:  {0}".format(str(e))
     else:
       try:
         response = urllib.urlopen(urlData)
         return response
       except Exception as e:
-        print "Error:  {}".format(str(e))
+        print "Error:  {0}".format(str(e))
 
 def fetch_clusterhealth():
     try:
@@ -128,7 +128,7 @@ def post_data(data):
         else:
             response = urllib2.urlopen(req)
     except Exception as e:
-        print "Error:  {}".format(str(e))
+        print "Error:  {0}".format(str(e))
 
 
 def main():


### PR DESCRIPTION
print "Error:  {}".format(str(e)) will cause error in python 2.6.6, and stop the script.

Traceback (most recent call last):
  File "/home/calmzeal/elasticsearch2elastic.py", line 149, in <module>
    main()
  File "/home/calmzeal/elasticsearch2elastic.py", line 135, in main
    clusterName = fetch_clusterhealth()
  File "/home/calmzeal/elasticsearch2elastic.py", line 63, in fetch_clusterhealth
    post_data(jsonData)
  File "/home/calmzeal/elasticsearch2elastic.py", line 131, in post_data
    print "Error:  {}".format(str(e))
ValueError: zero length field name in format