### PR TITLE
Update elasticsearch2elastic.py

### DIFF
--- a/Grafana/elasticsearch2elastic.py
+++ b/Grafana/elasticsearch2elastic.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import datetime
 import time
-import urllib
 import json
 import urllib2
 import os
@@ -40,7 +39,7 @@ def handle_urlopen(urlData, read_username, read_password):
         print "Error:  {0}".format(str(e))
     else:
       try:
-        response = urllib.urlopen(urlData)
+        response = urllib2.urlopen(urlData)
         return response
       except Exception as e:
         print "Error:  {0}".format(str(e))


### PR DESCRIPTION
Hi @trevorndodds , Could you help to merge it?

When use squid as proxy, urllib.open will meet issue. Change to use urllib2
ES version: 6.5.4


When setup squid http proxy
```
[root@xxx admin]# export |grep http
declare -x http_proxy="http://10.62.4.75:3128/"
declare -x https_proxy="https://10.62.4.75:3128/"
```

Test script
test.py 
```
#!/usr/bin/env python
import datetime
import time
import urllib
import json
import urllib2
import os
import sys

urlData = "http://es-ss.xxxx.com:9200/_cluster/health"
response = urllib.urlopen(urlData)
jsonData = json.loads(response.read())

print(jsonData)
```

Result
```
python test.py 
{u'error': u'no handler found for uri [http://es-ss.tng.mgsops.com:9200/_cluster/health] and method [GET]'}
```

Change to urlib2
test.py
```
#!/usr/bin/env python
import datetime
import time
#import urllib
import json
import urllib2
import os
import sys

urlData = "http://es-ss.xxxx.com:9200/_cluster/health"
response = urllib2.urlopen(urlData)
jsonData = json.loads(response.read())

print(jsonData)

```

Result
```
python test.py 
{u'status': u'green', u'number_of_nodes': 15, u'unassigned_shards': 0, u'number_of_pending_tasks': 0, u'number_of_in_flight_fetch': 0, u'timed_out': False, u'active_primary_shards': 5891, u'task_max_waiting_in_queue_millis': 0, u'cluster_name': u'sseast_tng', u'relocating_shards': 0, u'active_shards_percent_as_number': 100.0, u'active_shards': 11781, u'initializing_shards': 0, u'number_of_data_nodes': 13, u'delayed_unassigned_shards': 0}
```